### PR TITLE
Add XploitScan to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ List of awesome resources about CI/CD security included books, blogs, videos, to
 - [octoscan](https://github.com/synacktiv/octoscan) - Octoscan is a static vulnerability scanner for GitHub action workflows.
 - [segspec](https://github.com/dormstern/segspec) - Extracts network dependencies from application config files and generates Kubernetes NetworkPolicies. Diff mode enables CI gating to catch unauthorized network changes before deployment.
 - [gh-hijack-runner](https://github.com/synacktiv/gh-hijack-runner) - A python script to create a fake GitHub runner and hijack pipeline jobs to leak CI/CD secrets.
+- [XploitScan](https://xploitscan.com) - SAST scanner for JavaScript, TypeScript, and Node.js codebases that runs as a GitHub Action with SARIF output, surfacing 158 rules worth of findings (secrets, injection, XSS, SSRF, prototype pollution, crypto misuse) directly in GitHub's code scanning tab. Also available as a CLI and VSCode extension.
 
 ## Playground
 


### PR DESCRIPTION
Adding XploitScan under `## Tools`. It's a JS/TS SAST scanner that's designed to drop into CI as a GitHub Action and feed findings into GitHub's native code scanning via SARIF — fits the CI/CD-security theme of this list.

Homepage: https://xploitscan.com. Distribution is a GitHub Action, npm CLI, and VSCode extension. Freemium — free tier for open source / small projects, paid tiers unlock the full 158-rule set, PDF reports, and Slack/Discord webhooks for pipeline alerts.