### PR TITLE
Add articles on GitHub Actions OIDC secretless authentication and API protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ List of awesome resources about CI/CD security included books, blogs, videos, to
 - [GitHub Actions exploitation: self hosted runners](https://www.synacktiv.com/publications/github-actions-exploitation-self-hosted-runners)
 - [GitHub Actions exploitation: Dependabot](https://www.synacktiv.com/publications/github-actions-exploitation-dependabot)
 - [Hijacking GitHub runners to compromise the organization](https://www.synacktiv.com/publications/hijacking-github-runners-to-compromise-the-organization)
+- [GitHub Actions OIDC – Non-Human Identities and Secretless Authentication](https://eparon.me/posts/2026-02-28-oidc-gh-actions-p1/)
+- [Securing APIs with GitHub Actions OIDC and Envoy Proxy](https://eparon.me/posts/2026-03-24-oidc-gh-actions-p2/)
 
 ### Jenkins
 


### PR DESCRIPTION
## What

Adds two articles to the GitHub Actions section under Blogs:

- Part 1: How GitHub Actions issues OIDC tokens and how to use them for secret-less authentication — covers non-human identities, token claims, and the trust chain from GitHub's IdP.
- Part 2: End-to-end guide to protecting APIs using GitHub Actions OIDC tokens validated by Envoy Proxy, handling both authentication (authN) and authorization (authZ) concerns, as well as a reproducible lab setup.

## Why

The existing GitHub Actions entries cover the attack surface (secret theft, argument injection, write-access abuse). These two articles cover the defensive side — eliminating long-lived secrets from CI/CD pipelines entirely via workload identity. Complements what's already there.

---
Happy to take along any edits/suggestions prior to merging.