### PR TITLE
Add glsec to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ List of awesome resources about CI/CD security included books, blogs, videos, to
 - [gh-hijack-runner](https://github.com/synacktiv/gh-hijack-runner) - A python script to create a fake GitHub runner and hijack pipeline jobs to leak CI/CD secrets.
 - [zizmor](https://github.com/zizmorcore/zizmor) - Static analysis for GitHub Actions.
 - [actionlint](https://github.com/rhysd/actionlint) - A static checker for GitHub Actions workflow files.
+- [glsec](https://github.com/glsec/glsec) - Static security scanner for GitLab CI/CD pipelines, with rules mapped to the OWASP Top 10 CI/CD Security Risks. Offline, SARIF output.
 
 ## Playground
 


### PR DESCRIPTION
Adds [glsec](https://github.com/glsec/glsec), a static security scanner for GitLab CI/CD pipelines (`.gitlab-ci.yml`). It ships rules mapped to the OWASP Top 10 CI/CD Security Risks, runs fully offline, and outputs SARIF.

Follows the contributing format `[Name](link) - Description`; added to the Tools section; not a duplicate (no GitLab-CI static scanner currently listed there).